### PR TITLE
fix: 修复文件上传

### DIFF
--- a/src/modules/cos/index.ts
+++ b/src/modules/cos/index.ts
@@ -529,7 +529,7 @@ export default class Cos {
         const item = items[i];
         // 如果是文件夹跳过
         if (item.stats.isDirectory()) {
-          return;
+          continue;
         }
 
         key = path.relative(inputs.dir!, item.path);


### PR DESCRIPTION
修复文件夹上传cos失败
之前使用forEach 遇到return只会跳出当前循环
使用for 遇到return会跳出整个循环，改为continue，只跳出本次循环