### PR TITLE
fix: tags判断传空时不操作资源标签

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tencent-component-toolkit",
-  "version": "2.18.1",
+  "version": "2.24.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/modules/apigw/index.ts
+++ b/src/modules/apigw/index.ts
@@ -152,15 +152,17 @@ export default class Apigw {
     }
 
     try {
-      const { tags = [] } = inputs;
-      await this.tagClient.deployResourceTags({
-        tags: tags.map(({ key, value }) => ({ TagKey: key, TagValue: value })),
-        resourceId: serviceId,
-        serviceType: ApiServiceType.apigw,
-        resourcePrefix: 'service',
-      });
-      if (tags.length > 0) {
-        outputs.tags = tags;
+      const { tags } = inputs;
+      if (tags) {
+        await this.tagClient.deployResourceTags({
+          tags: tags.map(({ key, value }) => ({ TagKey: key, TagValue: value })),
+          resourceId: serviceId,
+          serviceType: ApiServiceType.apigw,
+          resourcePrefix: 'service',
+        });
+        if (tags.length > 0) {
+          outputs.tags = tags;
+        }
       }
     } catch (e) {
       console.log(`[TAG] ${e.message}`);
@@ -299,19 +301,18 @@ export default class Apigw {
         apiList,
       };
 
-      const { tags = [] } = inputs;
-      if (tags.length > 0) {
-        const deployedTags = await this.tagClient.deployResourceTags({
+      const { tags } = inputs;
+      if (tags) {
+        await this.tagClient.deployResourceTags({
           tags: tags.map(({ key, value }) => ({ TagKey: key, TagValue: value })),
           resourceId: serviceId,
           serviceType: ApiServiceType.apigw,
           resourcePrefix: 'service',
         });
 
-        outputs.tags = deployedTags.map((item) => ({
-          key: item.TagKey,
-          value: item.TagValue!,
-        }));
+        if (tags.length > 0) {
+          outputs.tags = tags;
+        }
       }
 
       // return this.formatApigwOutputs(outputs);

--- a/src/modules/cdn/index.ts
+++ b/src/modules/cdn/index.ts
@@ -240,15 +240,17 @@ export default class Cdn {
       }
 
       try {
-        const { tags = [] } = inputs;
-        await this.tagClient.deployResourceTags({
-          tags: tags.map(({ key, value }) => ({ TagKey: key, TagValue: value })),
-          resourceId: Domain,
-          serviceType: ApiServiceType.cdn,
-          resourcePrefix: 'domain',
-        });
-        if (tags.length > 0) {
-          outputs.tags = tags;
+        const { tags } = inputs;
+        if (tags) {
+          await this.tagClient.deployResourceTags({
+            tags: tags.map(({ key, value }) => ({ TagKey: key, TagValue: value })),
+            resourceId: Domain,
+            serviceType: ApiServiceType.cdn,
+            resourcePrefix: 'domain',
+          });
+          if (tags.length > 0) {
+            outputs.tags = tags;
+          }
         }
       } catch (e) {
         console.log(`[TAG] ${e.message}`);

--- a/src/modules/cfs/index.ts
+++ b/src/modules/cfs/index.ts
@@ -102,16 +102,18 @@ export default class CFS {
     }
 
     try {
-      const { tags = [] } = inputs;
-      await this.tagClient.deployResourceTags({
-        tags: tags.map((item) => ({ TagKey: item.key, TagValue: item.value })),
-        serviceType: ApiServiceType.cfs,
-        resourcePrefix: 'filesystem',
-        resourceId: outputs.fileSystemId!,
-      });
+      const { tags } = inputs;
+      if (tags) {
+        await this.tagClient.deployResourceTags({
+          tags: tags.map((item) => ({ TagKey: item.key, TagValue: item.value })),
+          serviceType: ApiServiceType.cfs,
+          resourcePrefix: 'filesystem',
+          resourceId: outputs.fileSystemId!,
+        });
 
-      if (tags.length > 0) {
-        outputs.tags = tags;
+        if (tags.length > 0) {
+          outputs.tags = tags;
+        }
       }
     } catch (e) {
       console.log(`[TAG] ${e.message}`);

--- a/src/modules/cynosdb/index.ts
+++ b/src/modules/cynosdb/index.ts
@@ -160,16 +160,18 @@ export default class Cynosdb {
     }));
 
     try {
-      const { tags = [] } = inputs;
-      await this.tagClient.deployResourceTags({
-        tags: tags.map(({ key, value }) => ({ TagKey: key, TagValue: value })),
-        resourceId: outputs.clusterId!,
-        serviceType: ApiServiceType.cynosdb,
-        resourcePrefix: 'instance',
-      });
+      const { tags } = inputs;
+      if (tags) {
+        await this.tagClient.deployResourceTags({
+          tags: tags.map(({ key, value }) => ({ TagKey: key, TagValue: value })),
+          resourceId: outputs.clusterId!,
+          serviceType: ApiServiceType.cynosdb,
+          resourcePrefix: 'instance',
+        });
 
-      if (tags.length > 0) {
-        outputs.tags = tags;
+        if (tags.length > 0) {
+          outputs.tags = tags;
+        }
       }
     } catch (e) {
       console.log(`[TAG] ${e.message}`);

--- a/src/modules/postgresql/index.ts
+++ b/src/modules/postgresql/index.ts
@@ -131,16 +131,18 @@ export default class Postgresql {
     }
 
     try {
-      const { tags = [] } = inputs;
-      await this.tagClient.deployResourceTags({
-        tags: tags.map(({ key, value }) => ({ TagKey: key, TagValue: value })),
-        resourceId: dbDetail.DBInstanceId,
-        serviceType: ApiServiceType.postgres,
-        resourcePrefix: 'DBInstanceId',
-      });
+      const { tags } = inputs;
+      if (tags) {
+        await this.tagClient.deployResourceTags({
+          tags: tags.map(({ key, value }) => ({ TagKey: key, TagValue: value })),
+          resourceId: dbDetail.DBInstanceId,
+          serviceType: ApiServiceType.postgres,
+          resourcePrefix: 'DBInstanceId',
+        });
 
-      if (tags.length > 0) {
-        outputs.tags = tags;
+        if (tags.length > 0) {
+          outputs.tags = tags;
+        }
       }
     } catch (e) {
       console.log(`[TAG] ${e.message}`);

--- a/src/modules/vpc/index.ts
+++ b/src/modules/vpc/index.ts
@@ -34,8 +34,8 @@ export default class Vpc {
       enableMulticast,
       dnsServers,
       domainName,
-      tags = [],
-      subnetTags = [],
+      tags,
+      subnetTags,
       enableSubnetBroadcast,
     } = inputs;
 
@@ -78,15 +78,17 @@ export default class Vpc {
         vId = res.VpcId;
       }
 
-      try {
-        await this.tagClient.deployResourceTags({
-          tags: tags.map(({ key, value }) => ({ TagKey: key, TagValue: value })),
-          resourceId: vId,
-          serviceType: ApiServiceType.vpc,
-          resourcePrefix: 'vpc',
-        });
-      } catch (e) {
-        console.log(`[TAG] ${e.message}`);
+      if (tags) {
+        try {
+          await this.tagClient.deployResourceTags({
+            tags: tags.map(({ key, value }) => ({ TagKey: key, TagValue: value })),
+            resourceId: vId,
+            serviceType: ApiServiceType.vpc,
+            resourcePrefix: 'vpc',
+          });
+        } catch (e) {
+          console.log(`[TAG] ${e.message}`);
+        }
       }
 
       return vId;
@@ -139,16 +141,18 @@ export default class Vpc {
         }
       }
 
-      const subnetTagList = subnetTags.length > 0 ? subnetTags : tags;
-      try {
-        await this.tagClient.deployResourceTags({
-          tags: subnetTagList.map(({ key, value }) => ({ TagKey: key, TagValue: value })),
-          resourceId: sId,
-          serviceType: ApiServiceType.vpc,
-          resourcePrefix: 'subnet',
-        });
-      } catch (e) {
-        console.log(`[TAG] ${e.message}`);
+      const subnetTagList = subnetTags ? subnetTags : tags;
+      if (subnetTagList) {
+        try {
+          await this.tagClient.deployResourceTags({
+            tags: subnetTagList.map(({ key, value }) => ({ TagKey: key, TagValue: value })),
+            resourceId: sId,
+            serviceType: ApiServiceType.vpc,
+            resourcePrefix: 'subnet',
+          });
+        } catch (e) {
+          console.log(`[TAG] ${e.message}`);
+        }
       }
       return sId;
     };
@@ -170,7 +174,7 @@ export default class Vpc {
       subnetName,
     };
 
-    if (tags.length > 0) {
+    if (tags && tags.length > 0) {
       outputs.tags = tags;
     }
 


### PR DESCRIPTION
问题：当前inputs中tags传空时，多种资源部署后tags会被清空。
调整：判断inputs中tags传空时不操作资源标签，除非显式传tags: []空数组才清空tags