### PR TITLE
feat: create alias

### DIFF
--- a/src/modules/scf/entities/alias.ts
+++ b/src/modules/scf/entities/alias.ts
@@ -13,17 +13,21 @@ import BaseEntity from './base';
 
 export default class AliasEntity extends BaseEntity {
   async create(inputs: ScfCreateAlias) {
-    const publishInputs = {
+    const publishInputs: any = {
       Action: 'CreateAlias' as const,
       FunctionName: inputs.functionName,
-      FunctionVersion: inputs.functionVersion,
+      FunctionVersion: inputs.functionVersion || '$LATEST',
       Name: inputs.aliasName,
       Namespace: inputs.namespace || 'default',
-      RoutingConfig: {
-        AdditionalVersionWeights: [{ Version: inputs.lastVersion, Weight: inputs.traffic }],
-      },
       Description: inputs.description || 'Published by Serverless Component',
     };
+    if (inputs.lastVersion && inputs.traffic) {
+      publishInputs.RoutingConfig = {
+        AdditionalVersionWeights: [
+          { Version: inputs.lastVersion, Weight: strip(1 - inputs.traffic) },
+        ],
+      };
+    }
     const Response = await this.request(publishInputs);
     return Response;
   }

--- a/src/modules/scf/interface.ts
+++ b/src/modules/scf/interface.ts
@@ -142,7 +142,7 @@ export interface ScfListAliasInputs extends ScfGetAliasInputs {}
 
 export interface ScfCreateAlias {
   functionName: string;
-  functionVersion: string;
+  functionVersion?: string;
   aliasName: string;
   namespace?: string;
   lastVersion: string;
@@ -279,6 +279,8 @@ export interface ScfDeployInputs extends ScfCreateFunctionInputs {
 
   aliasName?: string;
   aliasDescription?: string;
+  aliasFunctionVersion?: string;
+  aliasAddionalVersion?: string;
 
   tags?: Record<string, string>;
 


### PR DESCRIPTION
如果inputs传了aliasName就创建或更新这个别名
增加参数：
aliasFunctionVersion -> 别名主版本，未填默认为cli获取的函数版本即$LATEST
aliasAddionalVersion -> 别名其他版本，未默认为deploy中新发的版本
其他相关参数：
traffic -> 主版本的流量占比（0-1）